### PR TITLE
Extract item types to subclasses to encapsulate quality/sellIn change…

### DIFF
--- a/TypeScript/app/gilded-rose.ts
+++ b/TypeScript/app/gilded-rose.ts
@@ -1,20 +1,96 @@
+const MaximumQuality = 50;
+const MinimumQuality = 0;
+
 export class Item {
   name: string;
   sellIn: number;
   quality: number;
 
   constructor(name: string, sellIn: number, quality: number) {
+    if (quality < MinimumQuality || quality > MaximumQuality)
+      throw new Error("Quality must be between 0 and 50");
+
     this.name = name;
     this.sellIn = sellIn;
     this.quality = quality;
+  }
+
+  updateQuality() {
+    if (this.quality == MinimumQuality) return;
+
+    if (this.sellIn > 0) {
+      this.quality = this.quality - 1;
+    } else {
+      this.quality = this.quality - Math.min(this.quality, 2);
+    }
+  }
+
+  updateSellIn() {
+    this.sellIn = this.sellIn - 1;
+  }
+}
+
+export class AgedBrie extends Item {
+  updateQuality(): void {
+    if (this.quality == MaximumQuality) return;
+
+    if (this.sellIn < 1) {
+      this.quality = this.quality + 2; // More aged brie is sought after, so quality increases at a faster rate after sellIn date passes
+    } else {
+      this.quality = this.quality + 1;
+    }
+  }
+
+  constructor(sellIn: number, quality: number) {
+    super("Aged Brie", sellIn, quality);
+  }
+}
+
+export class Sulfuras extends Item {
+  updateQuality(): void {
+    return;
+  }
+
+  updateSellIn(): void {
+    return;
+  }
+
+  constructor() {
+    super("Sulfuras, Hand of Ragnaros", 0, MaximumQuality); // Sulfuras never has to be sold, and it's quality never decreases
+
+    // Hack: explicitly get around the 50 limit
+    // Worthy tradeoff as this is an uncommon case, other items should respect the limit
+    this.quality = 80;
+  }
+}
+
+export class BackstagePass extends Item {
+  updateQuality(): void {
+    // Concert has passed, there is no value in the ticket anymore
+    if (this.sellIn < 1) {
+      this.quality = MinimumQuality;
+      return;
+    }
+
+    if (this.quality == MaximumQuality) return;
+
+    // There is more demand in concert tickets as the concert date approaches, rate of quality increases accordingly
+    if (this.sellIn < 6) {
+      this.quality = this.quality + Math.min(3, MaximumQuality - this.quality);
+    } else if (this.sellIn < 11) {
+      this.quality = this.quality + Math.min(2, MaximumQuality - this.quality);
+    } else {
+      this.quality = this.quality + Math.min(1, MaximumQuality - this.quality);
+    }
+  }
+
+  constructor(sellIn: number, quality: number) {
+    super("Backstage passes to a TAFKAL80ETC concert", sellIn, quality);
   }
 }
 
 export class GildedRose {
   items: Array<Item>;
-
-  private readonly MaximumQuality = 50;
-  private readonly MinimumQuality = 0;
 
   constructor(items = [] as Array<Item>) {
     this.items = items;
@@ -22,64 +98,11 @@ export class GildedRose {
 
   updateQuality() {
     this.items.forEach((item) => {
-      this.updateItemQuality(item);
+      item.updateQuality();
 
-      this.updateItemSellInDate(item);
+      item.updateSellIn();
     });
 
     return this.items;
-  }
-
-  private updateItemSellInDate(item: Item) {
-    if (item.name != "Sulfuras, Hand of Ragnaros")
-      item.sellIn = item.sellIn - 1;
-  }
-
-  private updateItemQuality(item: Item) {
-    switch (item.name) {
-      case "Aged Brie":
-        if (item.quality == this.MaximumQuality) break;
-
-        if (item.sellIn < 1) {
-          item.quality = item.quality + 2; // More aged brie is sought after, so quality increases at a faster rate after sellIn date passes
-        } else {
-          item.quality = item.quality + 1;
-        }
-
-        break;
-      case "Backstage passes to a TAFKAL80ETC concert":
-        // Concert has passed, there is no value in the ticket anymore
-        if (item.sellIn < 1) {
-          item.quality = this.MinimumQuality;
-          break;
-        }
-
-        if (item.quality == this.MaximumQuality) break;
-
-        // There is more demand in concert tickets as the concert date approaches, rate of quality increases accordingly
-        if (item.sellIn < 6) {
-          item.quality =
-            item.quality + Math.min(3, this.MaximumQuality - item.quality);
-        } else if (item.sellIn < 11) {
-          item.quality =
-            item.quality + Math.min(2, this.MaximumQuality - item.quality);
-        } else {
-          item.quality =
-            item.quality + Math.min(1, this.MaximumQuality - item.quality);
-        }
-
-        break;
-      case "Sulfuras, Hand of Ragnaros":
-        break;
-      default: // Normal items
-        if (item.quality == this.MinimumQuality) break;
-
-        if (item.sellIn > 0) {
-          item.quality = item.quality - 1;
-        } else {
-          item.quality = item.quality - Math.min(item.quality, 2);
-        }
-        break;
-    }
   }
 }

--- a/TypeScript/test/jest/gilded-rose.spec.ts
+++ b/TypeScript/test/jest/gilded-rose.spec.ts
@@ -1,4 +1,10 @@
-import { Item, GildedRose } from "@/gilded-rose";
+import {
+  Item,
+  GildedRose,
+  AgedBrie,
+  Sulfuras,
+  BackstagePass,
+} from "@/gilded-rose";
 
 describe("Gilded Rose", () => {
   it("should foo", () => {
@@ -84,7 +90,7 @@ describe("All items", () => {
 describe("Aged Brie", () => {
   it("should increase quality by 1", () => {
     // Arrange
-    const normalItems = [new Item("Aged Brie", 1, 1)];
+    const normalItems = [new AgedBrie(1, 1)];
     const sut = new GildedRose(normalItems);
 
     // Act
@@ -96,8 +102,8 @@ describe("Aged Brie", () => {
 
   it("should not increase quality above 50", () => {
     // Arrange
-    const normalItems = [new Item("Aged Brie", 1, 50)];
-    const sut = new GildedRose(normalItems);
+    const agedBrie = [new AgedBrie(1, 50)];
+    const sut = new GildedRose(agedBrie);
 
     // Act
     const actual = sut.updateQuality();
@@ -108,8 +114,8 @@ describe("Aged Brie", () => {
 
   it("should increase quality by 2 after sell by date", () => {
     // Arrange
-    const normalItems = [new Item("Aged Brie", -1, 48)];
-    const sut = new GildedRose(normalItems);
+    const agedBrie = [new AgedBrie(-1, 48)];
+    const sut = new GildedRose(agedBrie);
 
     // Act
     const actual = sut.updateQuality();
@@ -121,12 +127,11 @@ describe("Aged Brie", () => {
 
 describe("Sulfuras", () => {
   // BUG: Quality can be set to negative
+  // BUG: Quality can be set to something outside of 80
   it.each([-1, 0, 1, 50])("should not change quality", (sulfurasQuality) => {
     // Arrange
-    const normalItems = [
-      new Item("Sulfuras, Hand of Ragnaros", 0, sulfurasQuality),
-    ];
-    const sut = new GildedRose(normalItems);
+    const sulfuras = [new Sulfuras()];
+    const sut = new GildedRose(sulfuras);
 
     // Act
     const actual = sut.updateQuality();
@@ -138,10 +143,8 @@ describe("Sulfuras", () => {
   // BUG: SellIn can be set to negative
   it.each([-1, 0, 1, 50])("should not change sellIn", (sulfurasSellIn) => {
     // Arrange
-    const normalItems = [
-      new Item("Sulfuras, Hand of Ragnaros", sulfurasSellIn, 13),
-    ];
-    const sut = new GildedRose(normalItems);
+    const sulfuras = [new Sulfuras()];
+    const sut = new GildedRose(sulfuras);
 
     // Act
     const actual = sut.updateQuality();
@@ -154,10 +157,8 @@ describe("Sulfuras", () => {
 describe("Backstage passes", () => {
   it("should increase quality by 1 when sellIn > 10", () => {
     // Arrange
-    const normalItems = [
-      new Item("Backstage passes to a TAFKAL80ETC concert", 11, 1),
-    ];
-    const sut = new GildedRose(normalItems);
+    const backstagePass = [new BackstagePass(11, 1)];
+    const sut = new GildedRose(backstagePass);
 
     // Act
     const actual = sut.updateQuality();
@@ -175,10 +176,8 @@ describe("Backstage passes", () => {
     "should increase quality by 2 when 10 >= sellIn > 5",
     (sellIn, quality, expectedQuality) => {
       // Arrange
-      const normalItems = [
-        new Item("Backstage passes to a TAFKAL80ETC concert", sellIn, quality),
-      ];
-      const sut = new GildedRose(normalItems);
+      const backstagePass = [new BackstagePass(sellIn, quality)];
+      const sut = new GildedRose(backstagePass);
 
       // Act
       const actual = sut.updateQuality();
@@ -198,10 +197,8 @@ describe("Backstage passes", () => {
     "should increase quality by 3 when 5 >= sellIn > 0",
     (sellIn, quality, expectedQuality) => {
       // Arrange
-      const normalItems = [
-        new Item("Backstage passes to a TAFKAL80ETC concert", sellIn, quality),
-      ];
-      const sut = new GildedRose(normalItems);
+      const backstagePass = [new BackstagePass(sellIn, quality)];
+      const sut = new GildedRose(backstagePass);
 
       // Act
       const actual = sut.updateQuality();
@@ -214,10 +211,8 @@ describe("Backstage passes", () => {
   // BUG: Possible to create a Backstage pass with negative sellIn and positive quality
   it("should drop quality to 0 after sell by date passes", () => {
     // Arrange
-    const normalItems = [
-      new Item("Backstage passes to a TAFKAL80ETC concert", 0, 10),
-    ];
-    const sut = new GildedRose(normalItems);
+    const backstagePass = [new BackstagePass(0, 10)];
+    const sut = new GildedRose(backstagePass);
 
     // Act
     const actual = sut.updateQuality();
@@ -232,9 +227,9 @@ describe("Multiple items", () => {
     // Arrange
     const items = [
       new Item("foo", 1, 1),
-      new Item("Aged Brie", 1, 1),
-      new Item("Sulfuras, Hand of Ragnaros", 1, 1),
-      new Item("Backstage passes to a TAFKAL80ETC concert", 1, 1),
+      new AgedBrie(1, 1),
+      new Sulfuras(),
+      new BackstagePass(1, 1),
     ];
     const sut = new GildedRose(items);
 
@@ -244,11 +239,9 @@ describe("Multiple items", () => {
     // Assert
     expect(actual.length).toBe(4);
     expect(actual[0]).toEqual(new Item("foo", 0, 0));
-    expect(actual[1]).toEqual(new Item("Aged Brie", 0, 2));
-    expect(actual[2]).toEqual(new Item("Sulfuras, Hand of Ragnaros", 1, 1));
-    expect(actual[3]).toEqual(
-      new Item("Backstage passes to a TAFKAL80ETC concert", 0, 4)
-    );
+    expect(actual[1]).toEqual(new AgedBrie(0, 2));
+    expect(actual[2]).toEqual(new Sulfuras());
+    expect(actual[3]).toEqual(new BackstagePass(0, 4));
   });
 });
 


### PR DESCRIPTION
Extract item types to subclasses to encapsulate quality/sellIn change behaviours - makes it super easy to understand behaviours or each item type, extend new item types, and also protect against invariants (objects with property values that shouldn't exist like Sulfuras with adjustable quality/sellIn dates). Failing tests expose weak points of previous implementation
